### PR TITLE
Improve button components and externalize React

### DIFF
--- a/admin/class-wps-boiler-plate-admin.php
+++ b/admin/class-wps-boiler-plate-admin.php
@@ -44,17 +44,13 @@ class WPS_Boiler_Plate_Admin {
             return;
         }
 
-        // If you BUNDLE React in build.js:
         wp_enqueue_script(
             'wpsbp-admin',
             $url,
-            [],
+            [ 'wp-element' ],
             filemtime( $path ),
             true
         );
-
-        // If you EXTERNALIZE React to WP in webpack (externals), use:
-        // wp_enqueue_script('wpsbp-admin', $url, ['wp-element'], filemtime($path), true);
 
         wp_localize_script( 'wpsbp-admin', 'WPSBP_ADMIN', [
             'ajaxUrl' => admin_url( 'admin-ajax.php' ),

--- a/components/WpsButton.jsx
+++ b/components/WpsButton.jsx
@@ -1,16 +1,30 @@
 import * as React from "react";
 import Button from "@mui/material/Button";
 
-export default function WpsButton(props) {
+export default function WpsButton({
+  id = "wps-btn",
+  className = "wps-btn",
+  variant = "contained",
+  size = "small",
+  children = "Click Me",
+  ...rest
+}) {
   return (
     <Button
-      id={props.id || "wps-btn"}
-      className={props.className || "wps-btn"}
-      variant={props.variant || "contained"}
-      size={props.size || "small"}
-      sx={{ display: "inline-block", borderRadius: "50px",padding: "12px", backgroundColor:"primary.purple" ,lineHeight:"1" }}
+      id={id}
+      className={className}
+      variant={variant}
+      size={size}
+      sx={{
+        display: "inline-block",
+        borderRadius: "50px",
+        padding: "12px",
+        backgroundColor: "primary.purple",
+        lineHeight: "1",
+      }}
+      {...rest}
     >
-      {props.children || "Click Me"}
+      {children}
     </Button>
   );
 }

--- a/components/WpsIconButton.jsx
+++ b/components/WpsIconButton.jsx
@@ -2,18 +2,30 @@ import * as React from "react";
 import Button from "@mui/material/Button";
 import SendIcon from "@mui/icons-material/Send";
 
-export default function WpsIconButton(props) {
+export default function WpsIconButton({
+  id = "wps-icon-btn",
+  className = "wps-icon-btn",
+  variant = "contained",
+  endIcon = <SendIcon />,
+  href,
+  newTab = false,
+  sx = {},
+  children = "Send",
+  ...rest
+}) {
   return (
     <Button
-      id={props.id || "wps-icon-btn"}
-      className={props.className || "wps-icon-btn"}
-      variant={props.variant || "contained"}
-      endIcon={props.endIcon || <SendIcon />}
-      href={props.href} // external or internal URL
-      newTab={props.newTab || true}
-      sx={{lineHeight: "1.5", ...props.sx}}
+      id={id}
+      className={className}
+      variant={variant}
+      endIcon={endIcon}
+      href={href}
+      target={newTab ? "_blank" : undefined}
+      rel={newTab ? "noopener noreferrer" : undefined}
+      sx={{ lineHeight: "1.5", ...sx }}
+      {...rest}
     >
-      {props.children || "Send"}
+      {children}
     </Button>
   );
 }

--- a/modules/ButtonModule.jsx
+++ b/modules/ButtonModule.jsx
@@ -7,14 +7,14 @@ import Box from "@mui/material/Box";
 import { Stack } from "@mui/system";
 import Chip from "@mui/material/Chip";
 
+const propsList = ["children", "variant", "size", "id", "className"];
+
 export default function ButtonModule({
   title = "Simple Button",
   subtitle = "WpsButton.jsx",
   ctaLabel = "Click Me",
   onCta,
 }) {
-  const propsList = ["children", "variant", "size", "id", "classname"];
-
   return (
     <Grid container spacing={2} alignItems="start">
       <Grid item sx={{ maxWidth: "200px", width: "100%" }}>

--- a/public/class-wps-boiler-plate-public.php
+++ b/public/class-wps-boiler-plate-public.php
@@ -17,11 +17,7 @@ class WPS_Boiler_Plate_Public {
         $url  = WPSBP_URL . $rel;
 
         if ( file_exists( $path ) ) {
-            // If bundling React:
-            wp_register_script( 'wpsbp-public', $url, [], filemtime( $path ), true );
-
-            // If externalizing React to front (less common), do:
-            // wp_register_script( 'wpsbp-public', $url, [ 'wp-element' ], filemtime( $path ), true );
+            wp_register_script( 'wpsbp-public', $url, [ 'wp-element' ], filemtime( $path ), true );
         }
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,10 @@ const makeConfig = ({
   },
   devtool: mode === "production" ? false : "source-map",
   optimization: { minimize: mode === "production" },
+  externals: {
+    react: "React",
+    "react-dom": "ReactDOM",
+  },
 });
 
 module.exports = [


### PR DESCRIPTION
## Summary
- Forward extra props and onClick handlers in custom button components
- Replace non-standard `newTab` attribute and support standard target/rel
- Hoist ButtonModule `propsList` constant and externalize React via wp-element

## Testing
- `npm run build` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be98de1720832d8b82ff90877e3580